### PR TITLE
Simulate user registration (GIM-379)

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -320,6 +320,7 @@ services:
       AUTH_SERVICE_HOST: 0.0.0.0
       AUTH_SERVICE_INCLUDE_APIS: '[]'
       AUTH_SERVICE_RUN_AUTH_ADAPTER: "true"
+      AUTH_SERVICE_API_EXT_PATH: ''
       AUTH_SERVICE_OIDC_AUTHORITY_URL: http://op.test
       AUTH_SERVICE_OIDC_USERINFO_ENDPOINT: http://op.test/userinfo
       AUTH_SERVICE_OIDC_CLIENT_ID: test-client

--- a/.pylintrc
+++ b/.pylintrc
@@ -446,7 +446,7 @@ min-similarity-lines=4
 [DESIGN]
 
 # Maximum number of arguments for function / method.
-max-args=7
+max-args=8
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=9

--- a/features/30_user_registration.feature
+++ b/features/30_user_registration.feature
@@ -1,0 +1,23 @@
+@download @auth
+Feature: 30 User Registration
+  Users can register themselves and then login.
+
+  Scenario: Reqistration as a new user
+
+    Given the user "Dr. John Doe" is not yet registered
+    When the user "Dr. John Doe" retrieves the own user data
+    Then the response status code is "404"
+
+    When the user "Dr. John Doe" tries to register
+    Then the response status code is "201"
+    And the user data of "Dr. John Doe" is returned
+
+    When the user "Dr. John Doe" retrieves the own user data
+    Then the response status code is "200"
+    And the user data of "Dr. John Doe" is returned
+
+  Scenario: The data steward should be pre-registered
+
+    When the user "Data Steward" retrieves the own user data
+    Then the response status code is "200"
+    And the user data of "Data Steward" is returned

--- a/features/31_access_request.feature
+++ b/features/31_access_request.feature
@@ -1,5 +1,5 @@
 @download @ars
-Feature: 30 Access Request
+Feature: 31 Access Request
   As a user, I can ask for access request to a given dataset.
 
   Scenario: Requesting access to a dataset
@@ -7,12 +7,15 @@ Feature: 30 Access Request
     Given we have the state "metadata has been loaded into the system"
     And the claims repository is empty
     And no access requests have been made yet
+    And I am registered as "Dr. John Doe"
     And I am logged in as "Dr. John Doe"
 
     When I request access to the test dataset "DS_A"
     Then the response status code is "201"
     And an email has been sent to "helpdesk@ghga.de"
     And an email has been sent to "john.doe@home.org"
+
+  Scenario: Granting access to a dataset
 
     Given I am logged in as "Data Steward"
 

--- a/features/32_work_packages.feature
+++ b/features/32_work_packages.feature
@@ -1,10 +1,11 @@
 @download @wps
-Feature: 31 Work Packages
+Feature: 32 Work Packages
   As a user, I can create a work package for downloading a file
   and a download token corresponding ot that work package.
 
   Background:
     Given we have the state "John Doe is allowed to download the test dataset"
+    And I am registered as "Dr. John Doe"
     And I am logged in as "Dr. John Doe"
 
   Scenario: Starting work package creation

--- a/features/33_download_files.feature
+++ b/features/33_download_files.feature
@@ -1,5 +1,5 @@
 @download @files
-Feature: 32 Download files
+Feature: 33 Download files
   As a user, I can download files when I have a download token.
 
   Background:

--- a/fixtures/__init__.py
+++ b/fixtures/__init__.py
@@ -68,7 +68,7 @@ def config_fixture() -> Config:
 
 # pylint: disable=redefined-outer-name
 @fixture(name="fixtures", scope="session")
-def joint_fixture(  # pylint: disable=too-many-arguments
+def joint_fixture(
     config: Config,
     kafka: KafkaFixture,
     mongo: MongoFixture,

--- a/fixtures/config.py
+++ b/fixtures/config.py
@@ -22,7 +22,7 @@ from hexkit.config import config_from_yaml
 from hexkit.providers.akafka import KafkaConfig
 from hexkit.providers.mongodb import MongoDbConfig
 from hexkit.providers.s3 import S3Config
-from pydantic import SecretStr
+from pydantic import SecretStr, root_validator
 
 
 @config_from_yaml(prefix="tb")
@@ -34,6 +34,7 @@ class Config(
     """Config class for the test app."""
 
     # operation modes
+    use_api_gateway = False
     use_auth_adapter = True
     keep_state_in_db = True
 
@@ -108,6 +109,7 @@ class Config(
     ums_db_name: str = "auth"
     ums_users_collection: str = "users"
     ums_claims_collection: str = "claims"
+    ums_url: str = "http://ums:8080"
 
     # wps
     wps_db_name: str = "wps"
@@ -128,3 +130,17 @@ class Config(
     # test OP
     op_url: str = "http://op.test"
     op_issuer: str = "https://test-aai.ghga.de"
+
+    @root_validator(pre=False)
+    @classmethod
+    def check_operation_modes(cls, values):
+        """Check that operation modes are not conflicting."""
+        try:
+            if values["use_api_gateway"]:
+                if not values["use_auth_adapter"]:
+                    raise ValueError("API gateway always uses auth adapter")
+                if values["keep_state_in_db"]:
+                    raise ValueError("Cannot use database when using API gateway")
+        except (KeyError, ValueError) as error:
+            raise ValueError(f"Check operation modes: {error}") from error
+        return values

--- a/fixtures/config.py
+++ b/fixtures/config.py
@@ -22,7 +22,7 @@ from hexkit.config import config_from_yaml
 from hexkit.providers.akafka import KafkaConfig
 from hexkit.providers.mongodb import MongoDbConfig
 from hexkit.providers.s3 import S3Config
-from pydantic import SecretStr, root_validator
+from pydantic import Field, SecretStr, root_validator
 
 
 @config_from_yaml(prefix="tb")
@@ -34,9 +34,15 @@ class Config(
     """Config class for the test app."""
 
     # operation modes
-    use_api_gateway = False
-    use_auth_adapter = True
-    keep_state_in_db = True
+    use_api_gateway: bool = Field(
+        False, description="set to True for black-box testing"
+    )
+    use_auth_adapter: bool = Field(
+        True, description="set to True for token exchange via auth adapter"
+    )
+    keep_state_in_db: bool = Field(
+        True, description="set to True for saving state permanently"
+    )
 
     # directories
     base_dir: Path = Path(__file__).parent.parent

--- a/pytest.ini
+++ b/pytest.ini
@@ -25,6 +25,7 @@ bdd_features_base_dir = features
 markers =
   ars: tests related to the access request service
   artifacts: test fetching metadata artifacts
+  auth: registration and authentication
   browse: tests for the dataset browsing
   download: tests for the egress user journey
   files: tests related to file operations

--- a/steps/test_26_dataset_summary.py
+++ b/steps/test_26_dataset_summary.py
@@ -44,7 +44,7 @@ EXPECTED_SUMMARIES = {
         },
         "files_summary": {
             "count": 20,
-            "stats": {"format": [{"value": "FASTQ", "count": 20}], "size": 114708},
+            "stats": {"format": [{"value": "FASTQ", "count": 20}], "size": 58720716},
         },
     },
     "DS_A": {

--- a/steps/test_30_user_registration.py
+++ b/steps/test_30_user_registration.py
@@ -1,0 +1,102 @@
+# Copyright 2021 - 2023 Universität Tübingen, DKFZ, EMBL, and Universität zu Köln
+# for the German Human Genome-Phenome Archive (GHGA)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Step definitions for requesting access in the frontend"""
+
+from datetime import datetime, timedelta
+
+import httpx
+from ghga_service_commons.utils.utc_dates import now_as_utc
+
+from .conftest import TIMEOUT, JointFixture, given, parse, scenarios, then, when
+
+scenarios("../features/30_user_registration.feature")
+
+
+@given(parse('the user "{full_name}" is not yet registered'))
+def user_not_yet_registered(full_name: str, fixtures: JointFixture):
+    registered_users = fixtures.state.get_state("registered users") or {}
+    sub = fixtures.auth.get_sub(full_name)
+    if not fixtures.config.use_api_gateway:
+        fixtures.mongo.remove_document(
+            fixtures.config.ums_db_name,
+            fixtures.config.ums_users_collection,
+            {"ext_id": sub},
+        )
+        if sub in registered_users:
+            del registered_users[sub]
+            fixtures.state.set_state("registered users", registered_users)
+    assert sub not in registered_users
+
+
+@when(
+    parse('the user "{full_name}" retrieves the own user data'),
+    target_fixture="response",
+)
+def user_fetches_own_info(full_name: str, fixtures: JointFixture):
+    sub = fixtures.auth.get_sub(full_name)
+    url = f"{fixtures.config.ums_url}/users/{sub}"
+    headers = fixtures.auth.generate_headers(full_name)
+    return httpx.get(url, headers=headers, timeout=TIMEOUT)
+
+
+@when(
+    parse('the user "{full_name}" tries to register'),
+    target_fixture="response",
+)
+def user_registers(full_name: str, fixtures: JointFixture):
+    title, name = fixtures.auth.split_title(full_name)
+    email = fixtures.auth.get_email(name)
+    sub = fixtures.auth.get_sub(name)
+    user_data = {
+        "name": name,
+        "title": title,
+        "email": email,
+        "ext_id": sub,
+    }
+    url = f"{fixtures.config.ums_url}/users"
+    headers = fixtures.auth.generate_headers(full_name)
+    return httpx.post(url, json=user_data, headers=headers, timeout=TIMEOUT)
+
+
+@then(parse('the user data of "{full_name}" is returned'))
+def user_gets_id(full_name: str, fixtures: JointFixture, response: httpx.Response):
+    title, name = fixtures.auth.split_title(full_name)
+    email = fixtures.auth.get_email(full_name)
+    sub = fixtures.auth.get_sub(full_name)
+    user = response.json()
+    assert isinstance(user, dict)
+    user_id = user["id"]
+    assert user_id and "-" in user_id and len(user_id) > 6 and "@" not in user_id
+    assert user["name"] == name
+    assert user["title"] == title
+    assert user["email"] == email
+    assert user["ext_id"] == sub
+    assert user["status"] == "active"
+    registration_date = user.get("registration_date")
+    assert registration_date and isinstance(registration_date, str)
+    # the data steward has been pre-registered when the test bed started,
+    # but other users should have registered only when this test was running
+    registration_timedelta = timedelta(
+        seconds=60 * 60 * 24 * 7 if name == "Data Steward" else 60
+    )
+    assert (
+        now_as_utc() - registration_timedelta
+        < datetime.fromisoformat(registration_date)
+        <= now_as_utc()
+    )
+    registered_users = fixtures.state.get_state("registered users") or {}
+    registered_users[sub] = user_id
+    fixtures.state.set_state("registered users", registered_users)

--- a/steps/test_32_work_packages.py
+++ b/steps/test_32_work_packages.py
@@ -31,7 +31,7 @@ from .conftest import (
     when,
 )
 
-scenarios("../features/31_work_packages.feature")
+scenarios("../features/32_work_packages.feature")
 
 
 @given("no work packages have been created yet")
@@ -53,7 +53,7 @@ def announce_dataset(config: Config, mongo: MongoFixture):
 
 @when("the list of datasets is queried", target_fixture="response")
 def query_datasets(config: Config, login: LoginFixture):
-    user_id = login.user["_id"]
+    user_id = login.user.id
     url = f"{config.wps_url}/users/{user_id}/datasets"
     return httpx.get(url, headers=login.headers, timeout=TIMEOUT)
 
@@ -110,8 +110,7 @@ def create_work_package(
         "user_public_crypt4gh_key": fixtures.config.user_public_crypt4gh_key,
     }
     url = f"{fixtures.config.wps_url}/work-packages"
-    response = httpx.post(url, headers=login.headers, json=data, timeout=TIMEOUT)
-    return response
+    return httpx.post(url, headers=login.headers, json=data, timeout=TIMEOUT)
 
 
 @then(parse('the response contains a download token for "{file_scope}" files'))

--- a/steps/test_33_download_files.py
+++ b/steps/test_33_download_files.py
@@ -33,7 +33,7 @@ from .conftest import (
 )
 from .utils import verify_named_file
 
-scenarios("../features/32_download_files.feature")
+scenarios("../features/33_download_files.feature")
 
 
 @given("the download buckets are empty")


### PR DESCRIPTION
This PR makes the registration a part of the tested user journeys, instead of adding users directly to the database, which is not possible in black-box testing mode.

A new config setting `use_api_gateway` for black-box testing has been added, which will be fully implemented in GIM-323.