### PR TITLE
Add external  (black-box) testing mode (GIM 323)

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -122,7 +122,7 @@ services:
       - 8002:8080
 
   mass:
-    image: ghga/mass:0.3.1
+    image: ghga/mass:0.3.2
     restart: unless-stopped
     depends_on:
       mongodb:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -35,6 +35,8 @@ services:
       GHGA_CONNECTOR_PART_SIZE: 8589934592
       GHGA_CONNECTOR_WKVS_API_URL: http://wkvs
       # operation modes
+      TB_USE_API_GATEWAY: "false"
+      TB_USE_AUTH_ADAPTER: "true"
       TB_KEEP_STATE_IN_DB: "true"
       # Kafka
       TB_SERVICE_NAME: testbed_kafka

--- a/features/22_search_datasets.feature
+++ b/features/22_search_datasets.feature
@@ -4,7 +4,6 @@ Feature: 22 Search Datasets
 
   Background:
     Given we have the state "metadata has been loaded into the system"
-    And the database collection is prepared for searching
 
   Scenario: Verify searching with invalid query
     When I search documents with invalid query format

--- a/fixtures/config.py
+++ b/fixtures/config.py
@@ -26,11 +26,7 @@ from pydantic import Field, SecretStr, root_validator
 
 
 @config_from_yaml(prefix="tb")
-class Config(
-    KafkaConfig,
-    MongoDbConfig,
-    S3Config,
-):
+class Config(KafkaConfig, MongoDbConfig, S3Config):
     """Config class for the test app."""
 
     # operation modes

--- a/fixtures/mongo.py
+++ b/fixtures/mongo.py
@@ -21,7 +21,7 @@ from typing import Any, Generator, Mapping, Optional, Union
 
 from hexkit.providers.mongodb.provider import MongoDbDaoFactory
 from hexkit.providers.mongodb.testutils import MongoDbFixture as BaseMongoFixture
-from pymongo import TEXT, MongoClient
+from pymongo import MongoClient
 from pymongo.errors import ExecutionTimeout, OperationFailure
 from pytest import fixture
 
@@ -156,14 +156,6 @@ class MongoFixture(BaseMongoFixture):
         db = self.client[db_name]
         collection = db.get_collection(collection_name)
         collection.delete_many(document)
-
-    def index_collection(self, db_name: str, collection_name: str):
-        db = self.client[db_name]
-        indexes = db[collection_name].list_indexes()
-        for index in indexes:
-            if index["name"] == "$**_text":
-                return
-        db[collection_name].create_index(keys=[("$**", TEXT)])
 
 
 @fixture(name="mongo", scope="session")

--- a/fixtures/state.py
+++ b/fixtures/state.py
@@ -67,7 +67,7 @@ class MemoryStateStorage(StateStorage):
     def unset_state(self, state_regex: str):
         regex = re.compile(state_regex)
         for state_name, _ in self.memory_storage.items():
-            if regex.match(state_name):
+            if regex.search(state_name):
                 del self.memory_storage[state_name]
 
     def reset_state(self):

--- a/fixtures/state.py
+++ b/fixtures/state.py
@@ -108,7 +108,7 @@ def state_fixture(config: Config, mongo: MongoFixture) -> StateStorage:
     """Fixture that provides a state storage."""
     storage = (
         MongoStateStorage(mongo=mongo)
-        if config.keep_state_in_db
+        if config.keep_state_in_db or config.use_api_gateway
         else MemoryStateStorage()
     )
 

--- a/steps/conftest.py
+++ b/steps/conftest.py
@@ -174,16 +174,15 @@ def restore_data_stewardship(state: tuple[Any, Any], fixtures: JointFixture) -> 
 async def reset_state(fixtures: JointFixture):
     """Reset all state used by the Archive Test Bed."""
     fixtures.state.reset_state()  # empty state database
-    if fixtures.config.use_api_gateway:
+    if not fixtures.config.use_api_gateway:
         # When running the tests externally using the API gateway,
         # we do not have access permissions to the state databases,
         # so we rely on the deployment to start with a clean slate.
-        return
-    await fixtures.s3.empty_buckets()  # empty object storage
-    fixtures.kafka.delete_topics()  # empty event queues
-    saved_data_steward = fetch_data_stewardship(fixtures)
-    fixtures.mongo.empty_databases()  # empty service databases
-    restore_data_stewardship(saved_data_steward, fixtures)
+        await fixtures.s3.empty_buckets()  # empty object storage
+        fixtures.kafka.delete_topics()  # empty event queues
+        saved_data_steward = fetch_data_stewardship(fixtures)
+        fixtures.mongo.empty_databases()  # empty service databases
+        restore_data_stewardship(saved_data_steward, fixtures)
     fixtures.dsk.reset_work_dir()  # reset local submission registry
     empty_mail_server(fixtures.config)  # reset mail server
 

--- a/steps/test_13_load_metadata.py
+++ b/steps/test_13_load_metadata.py
@@ -61,6 +61,9 @@ def run_the_load_command(fixtures: JointFixture):
 
 @then("the stats for the datasets exist in the database")
 def check_stats_in_metldata_database(config: Config, mongo: MongoFixture):
+    if config.use_api_gateway:
+        # black-box testing: skip checking the database directly
+        return
     datasets = mongo.wait_for_documents(
         config.metldata_db_name, "art_stats_public_class_DatasetStats", {}
     )
@@ -102,6 +105,9 @@ def check_stats_in_metldata_database(config: Config, mongo: MongoFixture):
 
 @then("the test datasets exist as embedded dataset in the database")
 def check_datasets_in_metldata_database(config: Config, mongo: MongoFixture):
+    if config.use_api_gateway:
+        # black-box testing: skip checking the database directly
+        return
     datasets = mongo.wait_for_documents(
         config.metldata_db_name, "art_embedded_public_class_EmbeddedDataset", {}
     )
@@ -155,6 +161,9 @@ def check_datasets_in_metldata_database(config: Config, mongo: MongoFixture):
 
 @then("the test datasets are known to the work package service")
 def check_datasets_in_wps_database(config: Config, mongo: MongoFixture):
+    if config.use_api_gateway:
+        # black-box testing: skip checking the database directly
+        return
     datasets = mongo.wait_for_documents(config.wps_db_name, "datasets", {})
     assert datasets
     assert len(datasets) == 6

--- a/steps/test_22_search_datasets.py
+++ b/steps/test_22_search_datasets.py
@@ -17,26 +17,10 @@
 
 import httpx
 
-from .conftest import (
-    Config,
-    MongoFixture,
-    StateStorage,
-    given,
-    parse,
-    scenarios,
-    then,
-    when,
-)
+from .conftest import Config, StateStorage, parse, scenarios, then, when
 from .utils import get_dataset_overview, search_dataset_rpc
 
 scenarios("../features/22_search_datasets.feature")
-
-
-@given("the database collection is prepared for searching")
-def index_mass_collection(config: Config, mongo: MongoFixture):
-    mongo.index_collection(
-        db_name=config.mass_db_name, collection_name=config.mass_collection
-    )
 
 
 @when("I search documents with invalid query format", target_fixture="response")

--- a/steps/test_31_access_request.py
+++ b/steps/test_31_access_request.py
@@ -43,6 +43,10 @@ scenarios("../features/31_access_request.feature")
 
 @given("no access requests have been made yet")
 def ars_database_is_empty(fixtures: JointFixture):
+    if fixtures.config.use_api_gateway:
+        # black-box testing: cannot empty service database
+        assert not fixtures.state.get_state("is allowed to download")
+        return
     fixtures.mongo.empty_databases(fixtures.config.ars_db_name)
     fixtures.state.unset_state("is allowed to download")
 
@@ -50,6 +54,9 @@ def ars_database_is_empty(fixtures: JointFixture):
 @given("the claims repository is empty")
 def claims_repository_is_empty(fixtures: JointFixture):
     """Remove all claims except for the data steward claim."""
+    if fixtures.config.use_api_gateway:
+        # black-box testing: cannot empty service database
+        return
     saved_data_steward = fetch_data_stewardship(fixtures)
     fixtures.mongo.empty_databases(
         fixtures.config.ums_db_name,

--- a/steps/test_32_work_packages.py
+++ b/steps/test_32_work_packages.py
@@ -36,6 +36,10 @@ scenarios("../features/32_work_packages.feature")
 
 @given("no work packages have been created yet")
 def wps_database_is_empty(config: Config, mongo: MongoFixture, state: StateStorage):
+    if config.use_api_gateway:
+        # black-box testing: cannot empty service database
+        assert not state.get_state("dataset to be downloaded")
+        return
     mongo.empty_databases(config.wps_db_name, exclude_collections="datasets")
     state.unset_state("^a download token has been created for.*")
     state.unset_state("dataset to be downloaded")
@@ -44,6 +48,9 @@ def wps_database_is_empty(config: Config, mongo: MongoFixture, state: StateStora
 
 @given("the test datasets have been announced")
 def announce_dataset(config: Config, mongo: MongoFixture):
+    if config.use_api_gateway:
+        # black-box testing: cannot look into service database
+        return
     datasets = mongo.wait_for_documents(config.wps_db_name, "datasets", {}, number=2)
     assert datasets
     assert len(datasets) == 6

--- a/steps/test_32_work_packages.py
+++ b/steps/test_32_work_packages.py
@@ -39,11 +39,15 @@ def wps_database_is_empty(config: Config, mongo: MongoFixture, state: StateStora
     if config.use_api_gateway:
         # black-box testing: cannot empty service database
         assert not state.get_state("dataset to be downloaded")
+        assert not state.get_state("all files to be downloaded")
+        assert not state.get_state("vcf files to be downloaded")
+        assert not state.get_state("download token for all files")
+        assert not state.get_state("download token for vcf files")
         return
     mongo.empty_databases(config.wps_db_name, exclude_collections="datasets")
-    state.unset_state("^a download token has been created for.*")
+    state.unset_state("download token for")
     state.unset_state("dataset to be downloaded")
-    state.unset_state(".*files to be downloaded$")
+    state.unset_state("files to be downloaded")
 
 
 @given("the test datasets have been announced")

--- a/steps/test_33_download_files.py
+++ b/steps/test_33_download_files.py
@@ -38,7 +38,10 @@ scenarios("../features/33_download_files.feature")
 
 @given("the download buckets are empty")
 @async_step
-async def download_buckets_empty(s3: S3Fixture):
+async def download_buckets_empty(config: Config, s3: S3Fixture):
+    if config.use_api_gateway:
+        # black-box testing: cannot check buckets
+        return
     await s3.empty_given_buckets(["inbox", "staging"])
 
 


### PR DESCRIPTION
In this PR, we make the new config setting `use_api_gateway` modify the following behaviors:
- If it is set to `True`, we are in black-box testing mode.
- This means we cannot access the foundational services directly.
- In particular, we cannot reset state or peek into databases for intermediate results,
- instead we rely on the deployment to create a new environment with empty state.
- We also rely on the API gateway calling the auth adapter automatically to exchange tokens,
- which means we must provide external tokens when calling services,
- and make sure we call only the publicly available APIs.