### PR TITLE
Simplify configuration of external APIs

### DIFF
--- a/.devcontainer/init-scripts/dev/set_env.sh
+++ b/.devcontainer/init-scripts/dev/set_env.sh
@@ -54,7 +54,7 @@ pk 's/^TOKEN_HASH=\(.*\)/METLDATA_LOADER_TOKEN_HASHES=["\1"]/p' > metldata.env
 pk 's/^TOKEN_HASH=\(.*\)/FIS_TOKEN_HASHES=["\1"]/p' > fis.env
 pk "s/^C4GH_2_PRIV=/FIS_PRIVATE_KEY=/p" >> fis.env
 
-pk "s/^C4GH_2_PUB=/TB_FILE_INGEST_PUBKEY=/p" > tb.env
+pk "s/^C4GH_2_PUB=/TB_FIS_PUBKEY=/p" > tb.env
 pk "s/^C4GH_3_PRIV=/TB_USER_PRIVATE_CRYPT4GH_KEY=/p" >> tb.env
 pk "s/^C4GH_3_PUB=/TB_USER_PUBLIC_CRYPT4GH_KEY=/p" >> tb.env
 

--- a/.devcontainer/tb.yaml
+++ b/.devcontainer/tb.yaml
@@ -12,8 +12,6 @@ kafka_servers: ["kafka:9092"]
 
 # MongoDb
 db_connection_str: mongodb://testbed_user:testbed_key@mongodb
-service_db_names:
-  ["ars", "auth", "dcs", "ifrs", "metldata", "ucs", "wps", "mass"]
 
 # S3
 s3_endpoint_url: http://localstack:4566

--- a/.devcontainer/tb.yaml
+++ b/.devcontainer/tb.yaml
@@ -12,7 +12,8 @@ kafka_servers: ["kafka:9092"]
 
 # MongoDb
 db_connection_str: mongodb://testbed_user:testbed_key@mongodb
-service_db_names: ["ars", "auth", "dcs", "ifrs", "metldata", "ucs", "wps", "mass"]
+service_db_names:
+  ["ars", "auth", "dcs", "ifrs", "metldata", "ucs", "wps", "mass"]
 
 # S3
 s3_endpoint_url: http://localstack:4566
@@ -33,7 +34,7 @@ permanent_bucket: permanent
 wkvs_url: "http://wkvs"
 
 # file ingest
-fis_url: http://fis:8080/ingest
+fis_url: http://fis:8080
 
 # metldata
 metldata_db_name: "metldata"

--- a/.devcontainer/tb.yaml
+++ b/.devcontainer/tb.yaml
@@ -33,7 +33,7 @@ permanent_bucket: permanent
 wkvs_url: "http://wkvs"
 
 # file ingest
-file_ingest_url: http://fis:8080/ingest
+fis_url: http://fis:8080/ingest
 
 # metldata
 metldata_db_name: "metldata"
@@ -59,7 +59,7 @@ ifrs_metadata_collection: "file_metadata"
 mass_url: "http://mass:8080"
 
 # notifications
-mailhog_url: "http://mailhog:8025"
+mail_url: "http://mailhog:8025"
 
 # test OP
 op_url: "http://op.test"

--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# Local configuration
+*.local.yaml
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/fixtures/config.py
+++ b/fixtures/config.py
@@ -115,7 +115,7 @@ class Config(KafkaConfig, MongoDbConfig, S3Config):
     dsk_token_path: Path = Path.home() / ".ghga_data_steward_token.txt"
 
     # file ingest
-    fis_url: str = "http://fis:8080/ingest"
+    fis_url: str = "http://fis:8080"
     fis_pubkey: str
 
     # metldata

--- a/fixtures/config.py
+++ b/fixtures/config.py
@@ -87,7 +87,7 @@ class Config(KafkaConfig, MongoDbConfig, S3Config):
 
     # external base URL
     external_base_url: str = ""
-    external_apis: tuple[str, ...] = (
+    external_apis: list[str] = [  # noqa: RUF012
         "wkvs",
         "fis",
         "metldata",
@@ -97,7 +97,7 @@ class Config(KafkaConfig, MongoDbConfig, S3Config):
         "mass",
         "mail",
         "op",
-    )
+    ]
 
     # auth
     auth_basic: str = ""

--- a/fixtures/config.py
+++ b/fixtures/config.py
@@ -85,6 +85,20 @@ class Config(KafkaConfig, MongoDbConfig, S3Config):
 
     object_id: str = "testbed-event-object"
 
+    # external base URL
+    external_base_url: str = ""
+    external_apis: tuple[str, ...] = (
+        "wkvs",
+        "fis",
+        "metldata",
+        "ars",
+        "ums",
+        "wps",
+        "mass",
+        "mail",
+        "op",
+    )
+
     # auth
     auth_basic: str = ""
     auth_key_file = Path(__file__).parent.parent / ".devcontainer/auth.env"
@@ -101,8 +115,8 @@ class Config(KafkaConfig, MongoDbConfig, S3Config):
     dsk_token_path: Path = Path.home() / ".ghga_data_steward_token.txt"
 
     # file ingest
-    file_ingest_url: str = "http://fis:8080/ingest"
-    file_ingest_pubkey: str
+    fis_url: str = "http://fis:8080/ingest"
+    fis_pubkey: str
 
     # metldata
     metldata_db_name: str = "metldata"
@@ -130,7 +144,7 @@ class Config(KafkaConfig, MongoDbConfig, S3Config):
     mass_url: str = "http://mass:8080"
 
     # notifications
-    mailhog_url: str = "http://mailhog:8025"
+    mail_url: str = "http://mailhog:8025"
 
     # test OP
     op_url: str = "http://op.test"
@@ -148,4 +162,32 @@ class Config(KafkaConfig, MongoDbConfig, S3Config):
                 raise ValueError("Basic auth must only be used with API gateway")
         except (KeyError, ValueError) as error:
             raise ValueError(f"Check operation modes: {error}") from error
+        return values
+
+    @root_validator(pre=False)
+    @classmethod
+    def add_external_base_url(cls, values):
+        """Add external base URL for all external APIs.
+
+        This allows the external URLs to be specified as paths relative to the
+        external base URL to avoid repetition in the external mode configuration.
+        """
+        base_url = values["external_base_url"]
+        external_apis = values["external_apis"]
+        if base_url and external_apis:
+            if not base_url.startswith(("http://", "https://")):
+                raise ValueError("External base URL must be absolute")
+            base_url = base_url.rstrip("/")
+
+            for api in external_apis:
+                key = f"{api}_url"
+                try:
+                    url = values[key]
+                    if not url:
+                        raise KeyError("URL is empty")
+                except KeyError as error:
+                    raise ValueError(f"Missing value for {key}") from error
+                if "://" not in url:
+                    url = base_url + "/" + url.lstrip("/")
+                values[key] = url
         return values

--- a/steps/conftest.py
+++ b/steps/conftest.py
@@ -199,7 +199,7 @@ def set_state_clause(name: str, state: StateStorage):
 
 def empty_mail_server(fixtures: JointFixture):
     """Delete all e-mails from mail server"""
-    fixtures.http.delete(f"{fixtures.config.mailhog_url}/api/v1/messages")
+    fixtures.http.delete(f"{fixtures.config.mail_url}/api/v1/messages")
 
 
 @then(parse('the expected hit count is "{count:d}"'))

--- a/steps/test_12_upload_files.py
+++ b/steps/test_12_upload_files.py
@@ -122,10 +122,8 @@ def call_data_steward_kit_ingest(ingest_config_path: str, dsk_token_path: Path, 
 @given("the staging bucket is empty")
 @async_step
 async def staging_bucket_is_empty(fixtures: JointFixture):
-    if fixtures.config.use_api_gateway:
-        # black-box testing: cannot check staging bucket
-        return
-    await fixtures.s3.empty_given_buckets(["staging"])
+    config = fixtures.config
+    await fixtures.s3.empty_given_buckets([config.staging_bucket])
 
 
 @given("no file metadata exists")
@@ -210,8 +208,8 @@ async def check_uploaded_files_in_storage(
 @when("the file metadata is ingested", target_fixture="ingest_config")
 def ingest_file_metadata(fixtures: JointFixture) -> IngestConfig:
     ingest_config = IngestConfig(
-        file_ingest_url=fixtures.config.file_ingest_url,
-        file_ingest_pubkey=fixtures.config.file_ingest_pubkey,
+        file_ingest_url=fixtures.config.fis_url,
+        file_ingest_pubkey=fixtures.config.fis_pubkey,
         input_dir=fixtures.dsk.config.file_metadata_dir,
         submission_store_dir=fixtures.dsk.config.submission_store,
         map_files_fields=fixtures.dsk.config.metadata_file_fields,

--- a/steps/test_12_upload_files.py
+++ b/steps/test_12_upload_files.py
@@ -208,7 +208,7 @@ async def check_uploaded_files_in_storage(
 @when("the file metadata is ingested", target_fixture="ingest_config")
 def ingest_file_metadata(fixtures: JointFixture) -> IngestConfig:
     ingest_config = IngestConfig(
-        file_ingest_url=fixtures.config.fis_url,
+        file_ingest_url=fixtures.config.fis_url + "/ingest",
         file_ingest_pubkey=fixtures.config.fis_pubkey,
         input_dir=fixtures.dsk.config.file_metadata_dir,
         submission_store_dir=fixtures.dsk.config.submission_store,

--- a/steps/test_31_access_request.py
+++ b/steps/test_31_access_request.py
@@ -93,7 +93,7 @@ def check_email_sent_to(
     Wait for an e-mail to be received by the mail server. If it does not appear
     within the given timeout (in seconds), an AssertionError is raised.
     """
-    url = f"{fixtures.config.mailhog_url}/api/v2/search"
+    url = f"{fixtures.config.mail_url}/api/v2/search"
     slept: float = 0
     while slept < timeout:
         response = fixtures.http.get(

--- a/steps/test_33_download_files.py
+++ b/steps/test_33_download_files.py
@@ -37,11 +37,9 @@ scenarios("../features/33_download_files.feature")
 
 @given("the download buckets are empty")
 @async_step
-async def download_buckets_empty(config: Config, s3: S3Fixture):
-    if config.use_api_gateway:
-        # black-box testing: cannot check buckets
-        return
-    await s3.empty_given_buckets(["inbox", "staging"])
+async def download_buckets_empty(fixtures: JointFixture):
+    config = fixtures.config
+    await fixtures.s3.empty_given_buckets([config.inbox_bucket, config.staging_bucket])
 
 
 @given("I have an empty working directory for the GHGA connector")


### PR DESCRIPTION
This service simplifies the configuration of external API URLs by allowing to only specify the paths relative to the base URL of the API gateway.

Maybe the new setting "external APIs" can be used for the health checks as well. We could add another setting "interal APIs" that should be checked to *not* be reachable when using the API gateway.