### PR TITLE
Update CLI tools and use legacy upload commands

### DIFF
--- a/fixtures/config.py
+++ b/fixtures/config.py
@@ -23,7 +23,7 @@ from hexkit.config import config_from_yaml
 from hexkit.providers.akafka import KafkaConfig
 from hexkit.providers.mongodb import MongoDbConfig
 from hexkit.providers.s3 import S3Config
-from pydantic import Field, SecretStr, root_validator
+from pydantic import Field, SecretStr, model_validator
 
 
 @config_from_yaml(prefix="tb")
@@ -43,8 +43,8 @@ class Config(KafkaConfig, MongoDbConfig, S3Config):
 
     # directories
     base_dir: Path = Path(__file__).parent.parent
-    data_dir = base_dir / "example_data"
-    test_dir = base_dir / "test_data"
+    data_dir: Path = base_dir / "example_data"
+    test_dir: Path = base_dir / "test_data"
 
     # constants used in testing
     upload_part_size: int = 1024
@@ -105,7 +105,7 @@ class Config(KafkaConfig, MongoDbConfig, S3Config):
     internal_apis: list[str] = ["ekss", "auth_adapter"]  # noqa: RUF012
 
     # auth
-    auth_key_file = Path(__file__).parent.parent / ".devcontainer/auth.env"
+    auth_key_file: Path = Path(__file__).parent.parent / ".devcontainer/auth.env"
     auth_adapter_url: str = "http://auth:8080"
     auth_basic: str = ""  # for Basic Authentication
     upload_token: str = ""  # simple token for uploading metadata
@@ -162,21 +162,21 @@ class Config(KafkaConfig, MongoDbConfig, S3Config):
     # dcs
     dcs_url: str = "http://dcs:8080"
 
-    @root_validator(pre=False)
+    @model_validator(mode="after")
     @classmethod
     def check_operation_modes(cls, values):
         """Check that operation modes are not conflicting."""
         try:
-            if values["use_api_gateway"]:
-                if not values["use_auth_adapter"]:
+            if values.use_api_gateway:
+                if not values.use_auth_adapter:
                     raise ValueError("API gateway always uses auth adapter")
-            elif values["auth_basic"]:
+            elif values.auth_basic:
                 raise ValueError("Basic auth must only be used with API gateway")
         except (KeyError, ValueError) as error:
             raise ValueError(f"Check operation modes: {error}") from error
         return values
 
-    @root_validator(pre=False)
+    @model_validator(mode="after")
     @classmethod
     def add_external_base_url(cls, values):
         """Add base URL to all APIs.
@@ -184,8 +184,8 @@ class Config(KafkaConfig, MongoDbConfig, S3Config):
         This allows the URLs to be specified as paths relative to the external base URL
         to avoid repetition in the external mode configuration.
         """
-        base_url = values["external_base_url"]
-        apis = values["external_apis"] + values["internal_apis"]
+        base_url = values.external_base_url
+        apis = values.external_apis + values.internal_apis
         if base_url and apis:
             if not base_url.startswith(("http://", "https://")):
                 raise ValueError("External base URL must be absolute")
@@ -194,12 +194,12 @@ class Config(KafkaConfig, MongoDbConfig, S3Config):
             for api in apis:
                 key = f"{api}_url"
                 try:
-                    url = values[key]
+                    url = getattr(values, key)
                     if not url:
                         raise KeyError("URL is empty")
                 except KeyError as error:
                     raise ValueError(f"Missing value for {key}") from error
                 if "://" not in url:
                     url = base_url + "/" + url.lstrip("/")
-                    values[key] = url
+                    setattr(values, key, url)
         return values

--- a/fixtures/connector.py
+++ b/fixtures/connector.py
@@ -24,7 +24,7 @@ from collections.abc import Generator
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 from pytest import fixture
 
 from fixtures.config import Config

--- a/fixtures/dsk.py
+++ b/fixtures/dsk.py
@@ -19,10 +19,11 @@
 import os
 import shutil
 import tempfile
+import typing
 from collections.abc import Generator
 from pathlib import Path
 
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 from pytest import fixture
 
 BASE_DIR = Path(__file__).parent.parent
@@ -45,7 +46,7 @@ class DskConfig(BaseSettings):
     complete_metadata_path: Path = metadata_dir / "complete_metadata.json"
 
     metadata_model_file: str = "metadata_model.yaml"
-    metadata_file_fields: list = [
+    metadata_file_fields: typing.ClassVar[list] = [
         "analysis_process_output_files",
         "sample_files",
         "sequencing_process_files",

--- a/fixtures/dsk.py
+++ b/fixtures/dsk.py
@@ -19,7 +19,7 @@
 import os
 import shutil
 import tempfile
-import typing
+from typing import ClassVar
 from collections.abc import Generator
 from pathlib import Path
 
@@ -46,7 +46,7 @@ class DskConfig(BaseSettings):
     complete_metadata_path: Path = metadata_dir / "complete_metadata.json"
 
     metadata_model_file: str = "metadata_model.yaml"
-    metadata_file_fields: typing.ClassVar[list] = [
+    metadata_file_fields: ClassVar[list] = [
         "analysis_process_output_files",
         "sample_files",
         "sequencing_process_files",

--- a/fixtures/dsk.py
+++ b/fixtures/dsk.py
@@ -19,9 +19,9 @@
 import os
 import shutil
 import tempfile
-from typing import ClassVar
 from collections.abc import Generator
 from pathlib import Path
+from typing import ClassVar
 
 from pydantic_settings import BaseSettings
 from pytest import fixture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archive_test_bed"
-version = "0.1.0"
+version = "0.9.0-legacy"
 description = "GHGA Archive Test Bed"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "archive_test_bed"
-version = "0.9.0-legacy"
+version = "0.9.0+legacy"
 description = "GHGA Archive Test Bed"
 readme = "README.md"
 authors = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 # All your requirements go here. Please adapt as needed:
 
-ghga-connector==0.3.13
-ghga-datasteward-kit==0.6.0
+ghga-connector==1.1.2
+ghga-datasteward-kit==1.2.0
 
-ghga-event-schemas>=0.13.4,<0.14
-ghga-service-commons[auth,crypt]>=0.5,<0.6
-hexkit[test-all]>=0.10.2,<0.11
+ghga-event-schemas>=1.0,<1.1
+ghga-service-commons[auth,crypt]~=1.1.0
+hexkit[all]~=1.0.0
 
 crypt4gh==1.6
 
@@ -15,6 +15,6 @@ pytest-bdd==6.1.1
 pytest-cov==4.0.0
 
 click==8.1.3
-typer==0.7.0
+typer==0.9.0
 
 httpx==0.23.3

--- a/steps/test_01_health_check.py
+++ b/steps/test_01_health_check.py
@@ -77,7 +77,7 @@ def check_user_management_apis_are_healthy(fixtures: JointFixture):
     status_code = response.status_code
     if fixtures.config.use_api_gateway:
         assert status_code == 404, (
-            "The claims repository should bot be reachable from outside,"
+            "The claims repository should not be reachable from outside,"
             f" but responds with status code {status_code}"
         )
     else:

--- a/steps/test_12_upload_files.py
+++ b/steps/test_12_upload_files.py
@@ -48,7 +48,7 @@ def call_data_steward_kit_upload(
         [
             "ghga-datasteward-kit",
             "files",
-            "upload",
+            "legacy-upload",
             "--alias",
             file_object.object_id,
             "--input-path",
@@ -79,7 +79,7 @@ def call_data_steward_kit_batch_upload(
         [
             "ghga-datasteward-kit",
             "files",
-            "batch-upload",
+            "legacy-batch-upload",
             "--tsv",
             str(batch_files_tsv),
             "--config-path",
@@ -118,7 +118,7 @@ def call_data_steward_kit_ingest(ingest_config_path: str, dsk_token_path: Path, 
 
         assert (
             completed_ingest.stdout.strip()
-            == "Sucessfully sent all file upload metadata for ingest."
+            == "Successfully sent all file upload metadata for ingest."
         )
         assert not completed_ingest.stderr
 
@@ -212,8 +212,9 @@ async def check_uploaded_files_in_storage(
 @when("the file metadata is ingested", target_fixture="ingest_config")
 def ingest_file_metadata(fixtures: JointFixture) -> IngestConfig:
     ingest_config = IngestConfig(
-        file_ingest_url=fixtures.config.fis_url + "/ingest",
+        file_ingest_baseurl=fixtures.config.fis_url,
         file_ingest_pubkey=fixtures.config.fis_pubkey,
+        file_ingest_legacy_endpoint="/ingest",
         input_dir=fixtures.dsk.config.file_metadata_dir,
         submission_store_dir=fixtures.dsk.config.submission_store,
         map_files_fields=fixtures.dsk.config.metadata_file_fields,

--- a/steps/utils.py
+++ b/steps/utils.py
@@ -15,8 +15,9 @@
 
 """Utilities used in step functions"""
 
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 from urllib.parse import urljoin
 
 from fixtures import Config, JointFixture
@@ -38,13 +39,10 @@ FILE_OVERVIEW_KEYS = {
 
 def ingest_config_as_file(config: IngestConfig):
     """Create upload config file for data steward kit files ingest-upload-metadata"""
-    ingest_config = {
-        "file_ingest_url": config.file_ingest_url,
-        "file_ingest_pubkey": config.file_ingest_pubkey,
-        "submission_store_dir": str(config.submission_store_dir),
-        "input_dir": str(config.input_dir),
-        "map_files_fields": config.map_files_fields,
-    }
+    ingest_config: dict[str, Any] = {}
+    for field in config.model_fields.keys():
+        value = getattr(config, field)
+        ingest_config[field] = value if isinstance(value, list) else str(value)
 
     return write_data_to_yaml(data=ingest_config)
 


### PR DESCRIPTION
This PR creates a new branch from the tag `0.9.0` and refactors the usage of the `ghga-datasteward-kit` to test **legacy commands.**

It reflects the real user journey by employing the latest version of `ghga-datasteward-kit (1.2.0)` alongside the services in the `GHGA Archive 0.9` deployment. To prevent dependency issues, other CLI tools have been updated accordingly.

In the latest version the Archive Test Bed already functioning with the latest set of services and tools, the use of **legacy commands** is no longer necessary there. The current strategy for testing Archive 0.9 involves the use of the most recent CLI version but with **legacy commands**. To mirror actual use cases more accurately, I have decided to create a new tag `0.9.0+legacy` for this branch of the test bed. This also helps avoid the overhead associated with including multiple versions of `ghga-datasteward-kit` or multiple `FIS`.
